### PR TITLE
Some minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ type Msg
     | Selected Posix -- the external confirm msg
     | UpdatePicker DatePicker.DatePicker -- the internal update msg
 
-userDefinedDatePickerSettings : Settings Msg
+userDefinedDatePickerSettings : DatePicker.Settings Msg
 userDefinedDatePickerSettings =
     DatePicker.defaultSettings { internalMsg = UpdatePicker, externalMsg = Selected }
 ```
@@ -60,12 +60,18 @@ view : Model -> Html Msg
 view model =
     ...
     div []
-        [ button [ onClick <| OpenPicker ] [ text "Open Me!" ]
+        [ button [ onClick OpenPicker ] [ text "Open Me!" ]
         , DatePicker.view userDefinedDatePickerSettings model.picker
         ]
 ```
 
 While we are on the topic of the `DatePicker.view`, it is worth noting that this date picker does _not_ include an input or button to trigger the view to open, this is up to the user to define and allows the picker to be flexible across different use cases.
+
+Usage example with [elm-css](https://package.elm-lang.org/packages/rtfeldman/elm-css/latest):
+
+```elm
+Html.Styled.fromUnstyled <| DatePicker.view datePickerSettings model.picker
+```
 
 
 4) Now it is time for the meat and potatoes: handling the `DatePicker` updates, including `saving` the time selected in the picker to the calling module's model.

--- a/src/DurationDatePicker.elm
+++ b/src/DurationDatePicker.elm
@@ -2,6 +2,7 @@ module DurationDatePicker exposing
     ( DatePicker, init, view, subscriptions
     , Settings, defaultSettings
     , openPicker, closePicker
+    , isOpen
     )
 
 {-| A date picker component for picking a datetime range.
@@ -256,6 +257,18 @@ openPicker baseTime startTime endTime (DatePicker model) =
 closePicker : DatePicker -> DatePicker
 closePicker (DatePicker model) =
     DatePicker { model | status = Closed }
+
+
+{-| Indicates whether the DatePicker is open
+-}
+isOpen : DatePicker -> Bool
+isOpen (DatePicker { status }) =
+    case status of
+        Open _ ->
+            True
+
+        Closed ->
+            False
 
 
 type Msg

--- a/src/DurationDatePicker.elm
+++ b/src/DurationDatePicker.elm
@@ -28,7 +28,7 @@ import DatePicker.Icons as Icons
 import DatePicker.Styles
 import DatePicker.Utilities as Utilities
 import Html exposing (Html, button, div, select, text)
-import Html.Attributes exposing (class, id)
+import Html.Attributes exposing (attribute, class, id, type_)
 import Html.Events exposing (on, onClick, onMouseOut, onMouseOver)
 import Html.Events.Extra exposing (targetValueIntParse)
 import Json.Decode as Decode
@@ -828,7 +828,7 @@ viewConfirmButton settings baseTime model =
                         ( classPrefix ++ "confirm-button", [ onClick <| settings.selectedMsg unifiedStart unifiedEnd ] )
 
         confirmAttrs =
-            [ class classStr ] ++ confirmAction
+            [ class classStr, type_ "button", attribute "aria-label" "confirm" ] ++ confirmAction
     in
     button confirmAttrs
         [ Icons.check

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -28,7 +28,7 @@ import DatePicker.Icons as Icons
 import DatePicker.Styles
 import DatePicker.Utilities as Utilities
 import Html exposing (Html, button, div, select, text)
-import Html.Attributes exposing (class, id)
+import Html.Attributes exposing (attribute, class, id, type_)
 import Html.Events exposing (on, onClick)
 import Html.Events.Extra exposing (targetValueIntParse)
 import Json.Decode as Decode
@@ -401,7 +401,7 @@ viewConfirmButton settings pickedTime =
                 |> Maybe.withDefault ( classPrefix ++ "confirm-button " ++ classPrefix ++ "disabled", [] )
 
         confirmAttrs =
-            [ class classStr ] ++ confirmAction
+            [ class classStr, type_ "button", attribute "aria-label" "confirm" ] ++ confirmAction
     in
     button confirmAttrs
         [ Icons.check

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -2,6 +2,7 @@ module SingleDatePicker exposing
     ( DatePicker, init, view, subscriptions
     , Settings, defaultSettings
     , openPicker, closePicker
+    , isOpen
     )
 
 {-| A date picker component for a single datetime.
@@ -181,6 +182,18 @@ openPicker baseTime pickedTime (DatePicker model) =
 closePicker : DatePicker -> DatePicker
 closePicker (DatePicker model) =
     DatePicker { model | status = Closed }
+
+
+{-| Indicates whether the DatePicker is open
+-}
+isOpen : DatePicker -> Bool
+isOpen (DatePicker { status }) =
+    case status of
+        Open _ ->
+            True
+
+        Closed ->
+            False
 
 
 type Msg


### PR DESCRIPTION
Started using this package and noticed some things that could be changed:

- The confirm button no longer submits automatically if it's inside a form because I put `type_ "button"` on it. This is good for users who put this component inside a form with other inputs inside.

- Added an `aria-label` for the confirm button for a11y

- Added an `isOpen` function for users to know if the picker is open or not

- Added example to readme on how to use this component if you are using elm-css

- Removed a backwards pipe in readme