### PR TITLE
Move settings and selected state into picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ Single and duration datetime picker components written in Elm 0.19
 
 This package exposes two modules `SingleDatePicker` and `DurationDatePicker`. As their names imply, `SingleDatePicker` can be used to pick a singular datetime while `DurationDatePicker` is used to select a datetime range. To keep things simple, the documentation here focuses on the `SingleDatePicker` but both types have an example app for additional reference.
 
-There are four steps to configure the `DatePicker`:
+There are three steps to configure the `DatePicker`:
 
-1) Add the picker to the model and initialize it in the model init
+1) Add the picker to the model and initialize it in the model init. The `DatePicker.init` function takes the configured
+settings for the picker as well as a `Maybe Posix` representing the previously picked datetime, if any.
+
+Both datepicker modules expose a `defaultSettings` method for configuring the settings. It takes a `Posix` representing the date around which the picker should center on if no datetime has been picked yet. It also takes a message defined by the user to handle updates internal to the datepicker. The function returns a `Settings` type which can be extended for further customization.
 
 ```elm
 import SingleDatePicker as DatePicker
@@ -31,57 +34,46 @@ type alias Model =
     , picker : DatePicker.DatePicker
     }
 
+type Msg
+    = ...
+    | UpdatePicker DatePicker.DatePicker
+
 init : ( Model, Cmd Msg )
 init =
     ( { ...
-      , picker = DatePicker.init
+      , picker = DatePicker.init (DatePicker.defaultSettings today UpdatePicker) Nothing
       }
     , Cmd.none
     )
 ```
-
-2) Two messages need to be defined: one for updates internal to the datepicker and one that indicates a datetime has been confirmed. These messages are added to the picker settings.
-
-```elm
-type Msg
-    = ...
-    | Selected Posix -- the external confirm msg
-    | UpdatePicker DatePicker.DatePicker -- the internal update msg
-
-userDefinedDatePickerSettings : DatePicker.Settings Msg
-userDefinedDatePickerSettings =
-    DatePicker.defaultSettings { internalMsg = UpdatePicker, externalMsg = Selected }
-```
     
-3) We call the `DatePicker.view` function, passing it the defined settings and the `DatePicker` instance to be operated on. Because the messages for handling picker updates are defined in the calling module and passed in via the settings, we do not need to worry about `Html.map`ping!
+2) Call the `DatePicker.view` function to render the picker, passing it the `DatePicker` instance to be operated on. Because the messages for handling picker updates are defined in the calling module and passed in via the settings, we do not need to worry about `Html.map`ping!
 
 ```elm
 view : Model -> Html Msg
 view model =
     ...
     div []
-        [ button [ onClick OpenPicker ] [ text "Open Me!" ]
-        , DatePicker.view userDefinedDatePickerSettings model.picker
+        [ button [ onClick <| OpenPicker ] [ text "Open Me!" ]
+        , DatePicker.view model.picker
         ]
 ```
 
 While we are on the topic of the `DatePicker.view`, it is worth noting that this date picker does _not_ include an input or button to trigger the view to open, this is up to the user to define and allows the picker to be flexible across different use cases.
 
 
-4) Now it is time for the meat and potatoes: handling the `DatePicker` updates, including `saving` the time selected in the picker to the calling module's model.
+3) Now it is time for the meat and potatoes: handling the `DatePicker` updates.
 
 ```elm
 type alias Model =
     { ...
     , today : Posix
-    , pickedTime : Maybe Posix
     , picker : DatePicker.DatePicker
     }
 
 type Msg
     = ...
     | OpenPicker
-    | Selected Posix
     | UpdatePicker DatePicker.DatePicker
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -90,23 +82,17 @@ update msg model =
         ...
 
         OpenPicker ->
-            ( { model | picker = DatePicker.openPicker model.today model.pickedTime model.picker }, Cmd.none )
-
-        Selected time ->
-            let
-                -- Don't want to close after confirming picked date? No problem, just remove the picker update!
-                newPicker =
-                    DatePicker.closePicker model.picker
-            in
-            ( { model | pickedTime = Just time, picker = newPicker }, Cmd.none )
+            ( { model | picker = DatePicker.openPicker model.picker }, Cmd.none )
 
         UpdatePicker newPicker ->
             ( { model | picker = newPicker }, Cmd.none )
 ```
 
-The user is responsible for defining his or her own `Open` picker message and placing the relevant event listener where he or she pleases. When handling this message in the `update` as seen above, we call `DatePicker.openPicker` which simply returns an updated picker instance to be stored on the model (`DatePicker.closePicker` is also provided and returns an updated picker instance like `openPicker` does). `DatePicker.openPicker` takes a `Posix` (the base time), a `Maybe Posix` (the picked time), and the `DatePicker` instance we wish to open. The base time is used to inform the picker what day it should center on in the event no datetime has been selected yet. This could be the current date or another date of the implementer's choosing.
+The user is responsible for defining his or her own `Open` picker message and placing the relevant event listener where he or she pleases. When handling this message in the `update` as seen above, we call `DatePicker.openPicker` which simply returns an updated picker instance to be stored on the model (`DatePicker.closePicker` is also provided and returns an updated picker instance like `openPicker` does).
 
-Remember those two messages we passed into the `DatePicker` settings? Here is where they come into play. One of them, `UpdatePicker` let's us know that an update of the `DatePicker` instance's internal state has occured. Seeing as we don't need to do any additional processing here, the `UpdatePicker` message simply carries the updated `DatePicker` instance along with it to save in the model of the calling module. `Selected` is an external message that notifies us that a datetime has been picked _and_ confirmed. This message carries the datetime that should be saved in the calling module.
+Remember that message we passed into the `DatePicker` settings? Here is where it comes into play. `UpdatePicker` let's us know that an update of the `DatePicker` instance's internal state has occured. Seeing as we don't need to do any additional processing here, the `UpdatePicker` message simply carries the updated `DatePicker` instance along with it to save in the model of the calling module.
+
+The picker also stores the current selection state. To access it, call `DatePicker.getPickedTime`.
 
 ## Automatically close the picker
 
@@ -115,7 +101,7 @@ In the event you want the picker to close automatically when clicking outside of
 ```elm
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    SingleDatePicker.subscriptions UpdatePicker model.picker
+    SingleDatePicker.subscriptions model.picker
 ```
 
 ## Additional Configuration
@@ -127,9 +113,9 @@ type alias Settings msg =
     { formattedDay : Weekday -> String
     , formattedMonth : Month -> String
     , today : Maybe Posix
+    , baseTime : Posix
     , dayDisabled : Posix -> Bool
-    , internalMsg : DatePicker -> msg
-    , selectedMsg : Posix -> msg
+    , internalMsg : DatePicker msg -> msg
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,33 +21,33 @@ This package exposes two modules `SingleDatePicker` and `DurationDatePicker`. As
 
 There are three steps to configure the `DatePicker`:
 
-1) Add the picker to the model and initialize it in the model init. The `DatePicker.init` function takes the configured
-settings for the picker as well as a `Maybe Posix` representing the previously picked datetime, if any.
+1) Add the picker to the model and initialize it in the model init. The `SingleDatePicker.init` function takes the configured
+settings. In the event you wish to `init` a picker with a previously picked datetime, simply pipe the result of the `init` to `SingleDatePicker.setPickedTime` passing the picked time.
 
 Both datepicker modules expose a `defaultSettings` method for configuring the settings. It takes a `Posix` representing the date around which the picker should center on if no datetime has been picked yet. It also takes a message defined by the user to handle updates internal to the datepicker. The function returns a `Settings` type which can be extended for further customization.
 
 ```elm
-import SingleDatePicker as DatePicker
+import SingleDatePicker
 
 type alias Model =
     { ...
-    , picker : DatePicker.DatePicker
+    , picker : SingleDatePicker.DatePicker
     }
 
 type Msg
     = ...
-    | UpdatePicker DatePicker.DatePicker
+    | UpdatePicker SingleDatePicker.DatePicker
 
 init : ( Model, Cmd Msg )
 init =
     ( { ...
-      , picker = DatePicker.init (DatePicker.defaultSettings today UpdatePicker) Nothing
+      , picker = SingleDatePicker.init (SingleDatePicker.defaultSettings today UpdatePicker) Nothing
       }
     , Cmd.none
     )
 ```
     
-2) Call the `DatePicker.view` function to render the picker, passing it the `DatePicker` instance to be operated on. Because the messages for handling picker updates are defined in the calling module and passed in via the settings, we do not need to worry about `Html.map`ping!
+2) Call the `SingleDatePicker.view` function to render the picker, passing it the `DatePicker` instance to be operated on. Because the messages for handling picker updates are defined in the calling module and passed in via the settings, we do not need to worry about `Html.map`ping!
 
 ```elm
 view : Model -> Html Msg
@@ -55,11 +55,11 @@ view model =
     ...
     div []
         [ button [ onClick <| OpenPicker ] [ text "Open Me!" ]
-        , DatePicker.view model.picker
+        , SingleDatePicker.view model.picker
         ]
 ```
 
-While we are on the topic of the `DatePicker.view`, it is worth noting that this date picker does _not_ include an input or button to trigger the view to open, this is up to the user to define and allows the picker to be flexible across different use cases.
+While we are on the topic of the `SingleDatePicker.view`, it is worth noting that this date picker does _not_ include an input or button to trigger the view to open, this is up to the user to define and allows the picker to be flexible across different use cases.
 
 
 3) Now it is time for the meat and potatoes: handling the `DatePicker` updates.
@@ -68,13 +68,13 @@ While we are on the topic of the `DatePicker.view`, it is worth noting that this
 type alias Model =
     { ...
     , today : Posix
-    , picker : DatePicker.DatePicker
+    , picker : SingleDatePicker.DatePicker
     }
 
 type Msg
     = ...
     | OpenPicker
-    | UpdatePicker DatePicker.DatePicker
+    | UpdatePicker SingleDatePicker.DatePicker
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
@@ -82,17 +82,17 @@ update msg model =
         ...
 
         OpenPicker ->
-            ( { model | picker = DatePicker.openPicker model.picker }, Cmd.none )
+            ( { model | picker = SingleDatePicker.openPicker model.picker }, Cmd.none )
 
         UpdatePicker newPicker ->
             ( { model | picker = newPicker }, Cmd.none )
 ```
 
-The user is responsible for defining his or her own `Open` picker message and placing the relevant event listener where he or she pleases. When handling this message in the `update` as seen above, we call `DatePicker.openPicker` which simply returns an updated picker instance to be stored on the model (`DatePicker.closePicker` is also provided and returns an updated picker instance like `openPicker` does).
+The user is responsible for defining his or her own `Open` picker message and placing the relevant event listener where he or she pleases. When handling this message in the `update` as seen above, we call `SingleDatePicker.openPicker` which simply returns an updated picker instance to be stored on the model (`SingleDatePicker.closePicker` is also provided and returns an updated picker instance like `openPicker` does).
 
 Remember that message we passed into the `DatePicker` settings? Here is where it comes into play. `UpdatePicker` let's us know that an update of the `DatePicker` instance's internal state has occured. Seeing as we don't need to do any additional processing here, the `UpdatePicker` message simply carries the updated `DatePicker` instance along with it to save in the model of the calling module.
 
-The picker also stores the current selection state. To access it, call `DatePicker.getPickedTime`.
+The picker also stores the current selection state. To access it, call `SingleDatePicker.getPickedTime`.
 
 ## Automatically close the picker
 
@@ -106,7 +106,7 @@ subscriptions model =
 
 ## Additional Configuration
 
-This is the settings type to be used when configuring the `datepicker`. More configuration will be available in future releases.
+This is the settings type to be used when configuring the `DatePicker`. More configuration will be available in future releases.
 
 ```elm
 type alias Settings msg =

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-datetime-picker",
     "summary": "a datetime picker component",
     "license": "MIT",
-    "version": "1.0.1",
+    "version": "2.0.0",
     "exposed-modules": [
         "DurationDatePicker",
         "SingleDatePicker"

--- a/examples/Basic/Main.elm
+++ b/examples/Basic/Main.elm
@@ -70,7 +70,7 @@ init currentTime =
             Time.millisToPosix currentTime
     in
     ( { today = today
-      , picker = SingleDatePicker.init (userDefinedDatePickerSettings today) Nothing
+      , picker = SingleDatePicker.init (userDefinedDatePickerSettings today)
       }
     , Cmd.none
     )

--- a/examples/Duration/Main.elm
+++ b/examples/Duration/Main.elm
@@ -70,7 +70,7 @@ init currentTime =
             Time.millisToPosix currentTime
     in
     ( { today = today
-      , picker = DurationDatePicker.init (userDefinedDatePickerSettings today) Nothing
+      , picker = DurationDatePicker.init (userDefinedDatePickerSettings today)
       }
     , Cmd.none
     )

--- a/src/DurationDatePicker.elm
+++ b/src/DurationDatePicker.elm
@@ -121,11 +121,10 @@ defaultSettings baseTime internalMsg =
     }
 
 
-{-| Instantiates and returns a date picker. Takes in the configured picker
-settings as well as the picked times, if any.
+{-| Instantiates and returns a date picker.
 -}
-init : Settings msg -> Maybe ( Posix, Posix ) -> DatePicker msg
-init settings pickedDateTimes =
+init : Settings msg -> DatePicker msg
+init settings =
     DatePicker
         { settings = settings
         , status = Closed <| Time.floor Day Time.utc settings.baseTime
@@ -136,8 +135,8 @@ init settings pickedDateTimes =
         , stagedStartTime = Nothing
         , stagedEndDay = Nothing
         , stagedEndTime = Nothing
-        , pickedStartDateTime = Maybe.map (\( s, _ ) -> s) pickedDateTimes
-        , pickedEndDateTime = Maybe.map (\( _, e ) -> e) pickedDateTimes
+        , pickedStartDateTime = Nothing
+        , pickedEndDateTime = Nothing
         }
 
 

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -105,17 +105,16 @@ defaultSettings baseTime internalMsg =
     }
 
 
-{-| Instantiates and returns a date picker. Takes in the configured picker
-settings as well as the picked time, if any.
+{-| Instantiates and returns a date picker.
 -}
-init : Settings msg -> Maybe Posix -> DatePicker msg
-init settings pickedTime =
+init : Settings msg -> DatePicker msg
+init settings =
     DatePicker
         { settings = settings
         , status = Closed <| Time.floor Day Time.utc settings.baseTime
         , viewOffset = 0
         , stagedTime = Nothing
-        , pickedTime = pickedTime
+        , pickedTime = Nothing
         }
 
 


### PR DESCRIPTION
## Changes

To improve ease of implementation, the configured settings and selected state have been moved into the picker state.

Helper methods `getPickedTime(s)` and `setPickedTime(s)` have been exposed to retrieve the selected state and set it in the event that the relevant data is not yet available or loaded when the picker is initialised.