### PR TITLE
Simplify Picker Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Single and duration datetime picker components written in Elm 0.19
 
 #### Single Picker
 
-![SinglePicker](https://user-images.githubusercontent.com/20546636/70621453-eb8f0400-1c19-11ea-8830-c21b53e616c0.gif)
+![SinglePicker](https://user-images.githubusercontent.com/20546636/70648536-8bb15100-1c4b-11ea-8faa-6f3fc9b9715a.gif)
 
 #### Duration Picker
 
-![DurationPicker](https://user-images.githubusercontent.com/20546636/70621436-df0aab80-1c19-11ea-8515-b4683737fc1b.gif)
+![DurationPicker](https://user-images.githubusercontent.com/20546636/70648518-7f2cf880-1c4b-11ea-8c6e-e97e4615c34c.gif)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -40,17 +40,16 @@ init =
     )
 ```
 
-2) Two messages need to be defined: one for updates internal to the datepicker and one that indicates a datetime has been confirmed. These messages are added to the picker settings.
+2) One message needs to be defined that expects an updated `DatePicker` instance as well as a `Maybe Posix` representing a datetime selection. This message is added to the picker settings.
 
 ```elm
 type Msg
     = ...
-    | Selected Posix -- the external confirm msg
-    | UpdatePicker DatePicker.DatePicker -- the internal update msg
+    | UpdatePicker ( DatePicker.DatePicker, Maybe Posix )
 
 userDefinedDatePickerSettings : DatePicker.Settings Msg
 userDefinedDatePickerSettings =
-    DatePicker.defaultSettings { internalMsg = UpdatePicker, externalMsg = Selected }
+    DatePicker.defaultSettings UpdatePicker
 ```
     
 3) We call the `DatePicker.view` function, passing it the defined settings and the `DatePicker` instance to be operated on. Because the messages for handling picker updates are defined in the calling module and passed in via the settings, we do not need to worry about `Html.map`ping!
@@ -81,8 +80,7 @@ type alias Model =
 type Msg
     = ...
     | OpenPicker
-    | Selected Posix
-    | UpdatePicker DatePicker.DatePicker
+    | UpdatePicker ( DatePicker.DatePicker, Maybe Posix )
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
@@ -92,21 +90,13 @@ update msg model =
         OpenPicker ->
             ( { model | picker = DatePicker.openPicker model.today model.pickedTime model.picker }, Cmd.none )
 
-        Selected time ->
-            let
-                -- Don't want to close after confirming picked date? No problem, just remove the picker update!
-                newPicker =
-                    DatePicker.closePicker model.picker
-            in
-            ( { model | pickedTime = Just time, picker = newPicker }, Cmd.none )
-
-        UpdatePicker newPicker ->
-            ( { model | picker = newPicker }, Cmd.none )
+        UpdatePicker ( newPicker, maybeNewTime ) ->
+            ( { model | picker = newPicker, pickedTime = Maybe.map (\t -> Just t) maybeNewTime |> Maybe.withDefault model.pickedTime }, Cmd.none )
 ```
 
 The user is responsible for defining his or her own `Open` picker message and placing the relevant event listener where he or she pleases. When handling this message in the `update` as seen above, we call `DatePicker.openPicker` which simply returns an updated picker instance to be stored on the model (`DatePicker.closePicker` is also provided and returns an updated picker instance like `openPicker` does). `DatePicker.openPicker` takes a `Posix` (the base time), a `Maybe Posix` (the picked time), and the `DatePicker` instance we wish to open. The base time is used to inform the picker what day it should center on in the event no datetime has been selected yet. This could be the current date or another date of the implementer's choosing.
 
-Remember those two messages we passed into the `DatePicker` settings? Here is where they come into play. One of them, `UpdatePicker` let's us know that an update of the `DatePicker` instance's internal state has occured. Seeing as we don't need to do any additional processing here, the `UpdatePicker` message simply carries the updated `DatePicker` instance along with it to save in the model of the calling module. `Selected` is an external message that notifies us that a datetime has been picked _and_ confirmed. This message carries the datetime that should be saved in the calling module.
+Remember that message we passed into the `DatePicker` settings? Here is where it comes into play. `UpdatePicker` let's us know that an update of the `DatePicker` instance's internal state has occured. Seeing as we don't need to do any additional processing here, the `UpdatePicker` message simply carries the updated `DatePicker` instance along with it to save in the model of the calling module. Additionally, we get a `Maybe Posix`. In the case of `Just` a time, we set that on the model as the new `pickedTime` otherwise we default to the current `pickedTime`.
 
 ## Automatically close the picker
 
@@ -128,8 +118,7 @@ type alias Settings msg =
     , formattedMonth : Month -> String
     , today : Maybe Posix
     , dayDisabled : Posix -> Bool
-    , internalMsg : DatePicker -> msg
-    , selectedMsg : Posix -> msg
+    , internalMsg : ( DatePicker, Maybe Posix ) -> msg
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Single and duration datetime picker components written in Elm 0.19
 
 #### Single Picker
 
-![SinglePicker](https://user-images.githubusercontent.com/20546636/64876897-82b2e280-d650-11e9-8b36-5609125b1665.gif)
+![SinglePicker](https://user-images.githubusercontent.com/20546636/70621453-eb8f0400-1c19-11ea-8830-c21b53e616c0.gif)
 
 #### Duration Picker
 
-![DurationPicker](https://user-images.githubusercontent.com/20546636/64876920-91999500-d650-11e9-8f56-3088930b64f7.gif)
+![DurationPicker](https://user-images.githubusercontent.com/20546636/70621436-df0aab80-1c19-11ea-8515-b4683737fc1b.gif)
 
 ## Usage
 

--- a/css/DurationDatePicker.css
+++ b/css/DurationDatePicker.css
@@ -45,23 +45,12 @@
 
 .elm-datetimepicker-duration--calendar-header-row {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
 }
 
 .elm-datetimepicker-duration--calendar-header-text {
     display: inline-flex;
     align-items: center;
-}
-
-.elm-datetimepicker-duration--calendar-header-chevron {
-    display: inline-flex;
-    align-items: center;
-    padding: 0 .5rem 0 .5rem;
-    cursor: pointer;
-}
-
-.elm-datetimepicker-duration--calendar-header-chevron:hover {
-    color: #38c172;
 }
 
 .elm-datetimepicker-duration--calendar-header-chevron.elm-datetimepicker-duration--hidden {

--- a/css/DurationDatePicker.css
+++ b/css/DurationDatePicker.css
@@ -138,14 +138,25 @@
 }
 
 .elm-datetimepicker-duration--time-pickers-container {
-    width: 150px;
+    width: 100%;
+}
+
+.elm-datetimepicker-duration--time-picker-information-container {
+    align-items: center;
+    width: 100%;
 }
 
 .elm-datetimepicker-duration--time-picker-container {
     display: inline-flex;
     justify-content: space-between;
     align-items: center;
-    width: 100%;
+    width: 35%;
+}
+
+.elm-datetimepicker-duration--date-display-container {
+    display: inline-flex;
+    justify-content: flex-end;
+    width: 65%;
 }
 
 .elm-datetimepicker-duration--time-picker {
@@ -162,34 +173,16 @@
     display: inline-flex;
 }
 
+.elm-datetimepicker-duration--selection-time {
+    margin-left: 5px;
+}
+
+.elm-datetimepicker-duration--selection-time-danger {
+    margin-left: 5px;
+    color: red;
+}
+
 .elm-datetimepicker-duration--select-spacer {
     display: inline-flex;
     padding: 0 .25rem 0 .25rem;
-}
-
-.elm-datetimepicker-duration--confirm-button-container {
-    display: inline-flex;
-    align-items: center;
-}
-
-.elm-datetimepicker-duration--confirm-button {
-    display: inline-flex;
-    height: 30px;
-    width: 50px;
-    border: 1px solid #a0aec0;
-    border-radius: 3px;
-    justify-content: center;
-    align-items: center;
-    color: #38c172;
-    cursor: pointer;
-}
-
-.elm-datetimepicker-duration--confirm-button:hover {
-    border-color: #38c172;
-}
-
-.elm-datetimepicker-duration--confirm-button.elm-datetimepicker-duration--disabled {
-    color: #a0aec0;
-    border-color: #a0aec0;
-    cursor: not-allowed;
 }

--- a/css/DurationDatePicker.css
+++ b/css/DurationDatePicker.css
@@ -8,15 +8,13 @@
     box-shadow: 0 2px 16px rgba(0, 0, 0, 0.15)
 }
 
-.elm-datetimepicker-duration--picker-header {
+.elm-datetimepicker-duration--picker-header-chevrons {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: .5rem;
 }
 
 .elm-datetimepicker-duration--picker-header-chevron {
-    display: inline-flex;
     cursor: pointer;
 }
 

--- a/css/SingleDatePicker.css
+++ b/css/SingleDatePicker.css
@@ -17,9 +17,14 @@
     font-weight: bold;
 }
 
-.elm-datetimepicker-single--calendar-header-row {
+.elm-datetimepicker-single--calendar-header-month {
     display: flex;
     justify-content: space-between;
+}
+
+.elm-datetimepicker-single--calendar-header-year {
+    display: flex;
+    justify-content: center;
 }
 
 .elm-datetimepicker-single--calendar-header-text {

--- a/css/SingleDatePicker.css
+++ b/css/SingleDatePicker.css
@@ -128,30 +128,3 @@
     display: inline-flex;
     padding: 0 .25rem 0 .25rem;
 }
-
-.elm-datetimepicker-single--confirm-button-container {
-    display: inline-flex;
-    align-items: center;
-}
-
-.elm-datetimepicker-single--confirm-button {
-    display: inline-flex;
-    height: 30px;
-    width: 50px;
-    border: 1px solid #a0aec0;
-    border-radius: 3px;
-    justify-content: center;
-    align-items: center;
-    color: #38c172;
-    cursor: pointer;
-}
-
-.elm-datetimepicker-single--confirm-button:hover {
-    border-color: #38c172;
-}
-
-.elm-datetimepicker-single--confirm-button.elm-datetimepicker-single--disabled {
-    color: #a0aec0;
-    border-color: #a0aec0;
-    cursor: not-allowed;
-}

--- a/css/SingleDatePicker.css
+++ b/css/SingleDatePicker.css
@@ -17,14 +17,9 @@
     font-weight: bold;
 }
 
-.elm-datetimepicker-single--calendar-header-month {
+.elm-datetimepicker-single--calendar-header-row {
     display: flex;
     justify-content: space-between;
-}
-
-.elm-datetimepicker-single--calendar-header-year {
-    display: flex;
-    justify-content: center;
 }
 
 .elm-datetimepicker-single--calendar-header-text {

--- a/src/DurationDatePicker.elm
+++ b/src/DurationDatePicker.elm
@@ -208,6 +208,8 @@ isOpen (DatePicker { status }) =
 type Msg
     = NextMonth
     | PrevMonth
+    | NextYear
+    | PrevYear
     | SetHoveredDay Posix
     | ClearHoveredDay
     | SetRange Posix ( Maybe Posix, Maybe Posix )
@@ -248,6 +250,12 @@ update msg (DatePicker model) =
 
                 PrevMonth ->
                     ( DatePicker { model | pickerOffset = model.pickerOffset - 1 }, Nothing )
+
+                NextYear ->
+                    ( DatePicker { model | pickerOffset = model.pickerOffset + 12 }, Nothing )
+
+                PrevYear ->
+                    ( DatePicker { model | pickerOffset = model.pickerOffset - 12 }, Nothing )
 
                 SetHoveredDay time ->
                     ( DatePicker { model | hovered = Just time }, Nothing )
@@ -402,22 +410,42 @@ view settings (DatePicker model) =
 
 viewPickerHeader : Settings msg -> Model -> Html msg
 viewPickerHeader settings model =
-    div [ class (classPrefix ++ "picker-header") ]
-        [ div
-            [ class (classPrefix ++ "picker-header-chevron")
-            , onClick <| settings.internalMsg <| update PrevMonth (DatePicker model)
+    div []
+        [ div [ class (classPrefix ++ "picker-header-chevrons") ]
+            [ div
+                [ class (classPrefix ++ "picker-header-chevron")
+                , onClick <| settings.internalMsg <| update PrevMonth (DatePicker model)
+                ]
+                [ Icons.chevronLeft
+                    |> Icons.withSize 15
+                    |> Icons.toHtml []
+                ]
+            , div
+                [ class (classPrefix ++ "picker-header-chevron")
+                , onClick <| settings.internalMsg <| update NextMonth (DatePicker model)
+                ]
+                [ Icons.chevronRight
+                    |> Icons.withSize 15
+                    |> Icons.toHtml []
+                ]
             ]
-            [ Icons.chevronLeft
-                |> Icons.withSize 15
-                |> Icons.toHtml []
-            ]
-        , div
-            [ class (classPrefix ++ "picker-header-chevron")
-            , onClick <| settings.internalMsg <| update NextMonth (DatePicker model)
-            ]
-            [ Icons.chevronRight
-                |> Icons.withSize 15
-                |> Icons.toHtml []
+        , div [ class (classPrefix ++ "picker-header-chevrons") ]
+            [ div
+                [ class (classPrefix ++ "picker-header-chevron")
+                , onClick <| settings.internalMsg <| update PrevYear (DatePicker model)
+                ]
+                [ Icons.chevronsLeft
+                    |> Icons.withSize 15
+                    |> Icons.toHtml []
+                ]
+            , div
+                [ class (classPrefix ++ "picker-header-chevron")
+                , onClick <| settings.internalMsg <| update NextYear (DatePicker model)
+                ]
+                [ Icons.chevronsRight
+                    |> Icons.withSize 15
+                    |> Icons.toHtml []
+                ]
             ]
         ]
 

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -199,8 +199,6 @@ isOpen (DatePicker { status }) =
 type Msg
     = NextMonth
     | PrevMonth
-    | NextYear
-    | PrevYear
     | SetDay Posix
     | SetHour Int
     | SetMinute Int
@@ -217,12 +215,6 @@ update msg (DatePicker model) =
 
                 PrevMonth ->
                     DatePicker { model | viewOffset = model.viewOffset - 1 }
-
-                NextYear ->
-                    DatePicker { model | viewOffset = model.viewOffset + 12 }
-
-                PrevYear ->
-                    DatePicker { model | viewOffset = model.viewOffset - 12 }
 
                 SetDay time ->
                     DatePicker { model | pickedTime = Just <| Utilities.setDayNotTime time (Maybe.withDefault (Time.floor Day Time.utc time) model.pickedTime) }
@@ -280,7 +272,7 @@ viewCalendarHeader settings model time =
     in
     div
         [ class (classPrefix ++ "calendar-header") ]
-        [ div [ class (classPrefix ++ "calendar-header-row") ]
+        [ div [ class (classPrefix ++ "calendar-header-month") ]
             [ div
                 [ class (classPrefix ++ "calendar-header-chevron")
                 , onClick <| settings.internalMsg <| update PrevMonth (DatePicker model)
@@ -301,26 +293,10 @@ viewCalendarHeader settings model time =
                     |> Icons.toHtml []
                 ]
             ]
-        , div [ class (classPrefix ++ "calendar-header-row") ]
+        , div [ class (classPrefix ++ "calendar-header-year") ]
             [ div
-                [ class (classPrefix ++ "calendar-header-chevron")
-                , onClick <| settings.internalMsg <| update PrevYear (DatePicker model)
-                ]
-                [ Icons.chevronsLeft
-                    |> Icons.withSize 12
-                    |> Icons.toHtml []
-                ]
-            , div
                 [ class (classPrefix ++ "calendar-header-text") ]
                 [ div [] [ text year ] ]
-            , div
-                [ class (classPrefix ++ "calendar-header-chevron")
-                , onClick <| settings.internalMsg <| update NextYear (DatePicker model)
-                ]
-                [ Icons.chevronsRight
-                    |> Icons.withSize 12
-                    |> Icons.toHtml []
-                ]
             ]
         , viewWeekHeader settings [ Sun, Mon, Tue, Wed, Thu, Fri, Sat ]
         ]

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -189,6 +189,8 @@ isOpen (DatePicker { status }) =
 type Msg
     = NextMonth
     | PrevMonth
+    | NextYear
+    | PrevYear
     | SetDay Posix
     | SetHour Int
     | SetMinute Int
@@ -205,6 +207,12 @@ update msg (DatePicker model) =
 
                 PrevMonth ->
                     ( DatePicker { model | viewOffset = model.viewOffset - 1 }, Nothing )
+
+                NextYear ->
+                    ( DatePicker { model | viewOffset = model.viewOffset + 12 }, Nothing )
+
+                PrevYear ->
+                    ( DatePicker { model | viewOffset = model.viewOffset - 12 }, Nothing )
 
                 SetDay time ->
                     let
@@ -274,7 +282,7 @@ viewCalendarHeader settings model time =
     in
     div
         [ class (classPrefix ++ "calendar-header") ]
-        [ div [ class (classPrefix ++ "calendar-header-month") ]
+        [ div [ class (classPrefix ++ "calendar-header-row") ]
             [ div
                 [ class (classPrefix ++ "calendar-header-chevron")
                 , onClick <| settings.internalMsg <| update PrevMonth (DatePicker model)
@@ -295,10 +303,26 @@ viewCalendarHeader settings model time =
                     |> Icons.toHtml []
                 ]
             ]
-        , div [ class (classPrefix ++ "calendar-header-year") ]
+        , div [ class (classPrefix ++ "calendar-header-row") ]
             [ div
+                [ class (classPrefix ++ "calendar-header-chevron")
+                , onClick <| settings.internalMsg <| update PrevYear (DatePicker model)
+                ]
+                [ Icons.chevronsLeft
+                    |> Icons.withSize 12
+                    |> Icons.toHtml []
+                ]
+            , div
                 [ class (classPrefix ++ "calendar-header-text") ]
                 [ div [] [ text year ] ]
+            , div
+                [ class (classPrefix ++ "calendar-header-chevron")
+                , onClick <| settings.internalMsg <| update NextYear (DatePicker model)
+                ]
+                [ Icons.chevronsRight
+                    |> Icons.withSize 12
+                    |> Icons.toHtml []
+                ]
             ]
         , viewWeekHeader settings [ Sun, Mon, Tue, Wed, Thu, Fri, Sat ]
         ]

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -62,8 +62,7 @@ type alias Settings msg =
     , formattedMonth : Month -> String
     , today : Maybe Posix
     , dayDisabled : Posix -> Bool
-    , internalMsg : DatePicker -> msg
-    , selectedMsg : Posix -> msg
+    , internalMsg : ( DatePicker, Maybe Posix ) -> msg
     }
 
 
@@ -72,31 +71,22 @@ type Status
     | Open Posix
 
 
-type alias MsgConfig msg =
-    { internalMsg : DatePicker -> msg
-    , externalMsg : Posix -> msg
-    }
-
-
 {-| A record of default settings for the date picker. Extend this if
 you want to further customize the date picker.
 
-Requires a MsgConfig msg record to set the date picker's internal and external
-msg indicators
+Requires a `msg` that expects a tuple containing a datepicker instance
+and a `Maybe Posix` representing a selected datetime.
 
-    { internalMsg : DatePicker -> msg
-    , externalMsg : Posix -> msg
-    }
+    ( DatePicker, Maybe ( Posix, Posix ) ) -> msg
 
 -}
-defaultSettings : MsgConfig msg -> Settings msg
-defaultSettings { internalMsg, externalMsg } =
+defaultSettings : (( DatePicker, Maybe Posix ) -> msg) -> Settings msg
+defaultSettings internalMsg =
     { formattedDay = Utilities.dayToNameString
     , formattedMonth = Utilities.monthToNameString
     , today = Nothing
     , dayDisabled = always False
     , internalMsg = internalMsg
-    , selectedMsg = externalMsg
     }
 
 
@@ -118,7 +108,7 @@ datePickerId =
 
 {-| Events external to the picker to which it is subscribed.
 -}
-subscriptions : (DatePicker -> msg) -> DatePicker -> Sub msg
+subscriptions : (( DatePicker, Maybe Posix ) -> msg) -> DatePicker -> Sub msg
 subscriptions internalMsg (DatePicker model) =
     case model.status of
         Open _ ->
@@ -128,7 +118,7 @@ subscriptions internalMsg (DatePicker model) =
             Sub.none
 
 
-clickedOutsidePicker : String -> (DatePicker -> msg) -> DatePicker -> Decode.Decoder msg
+clickedOutsidePicker : String -> (( DatePicker, Maybe Posix ) -> msg) -> DatePicker -> Decode.Decoder msg
 clickedOutsidePicker componentId internalMsg datePicker =
     Decode.field "target" (Utilities.eventIsOutsideComponent componentId)
         |> Decode.andThen
@@ -205,31 +195,43 @@ type Msg
     | Close
 
 
-update : Msg -> DatePicker -> DatePicker
+update : Msg -> DatePicker -> ( DatePicker, Maybe Posix )
 update msg (DatePicker model) =
     case model.status of
         Open baseTime ->
             case msg of
                 NextMonth ->
-                    DatePicker { model | viewOffset = model.viewOffset + 1 }
+                    ( DatePicker { model | viewOffset = model.viewOffset + 1 }, Nothing )
 
                 PrevMonth ->
-                    DatePicker { model | viewOffset = model.viewOffset - 1 }
+                    ( DatePicker { model | viewOffset = model.viewOffset - 1 }, Nothing )
 
                 SetDay time ->
-                    DatePicker { model | pickedTime = Just <| Utilities.setDayNotTime time (Maybe.withDefault (Time.floor Day Time.utc time) model.pickedTime) }
+                    let
+                        newTime =
+                            Just <| Utilities.setDayNotTime time (Maybe.withDefault (Time.floor Day Time.utc time) model.pickedTime)
+                    in
+                    ( DatePicker { model | pickedTime = newTime }, newTime )
 
                 SetHour hour ->
-                    DatePicker { model | pickedTime = Just <| Utilities.setHourNotDay hour (Maybe.withDefault (Time.floor Day Time.utc baseTime) model.pickedTime) }
+                    let
+                        newTime =
+                            Just <| Utilities.setHourNotDay hour (Maybe.withDefault (Time.floor Day Time.utc baseTime) model.pickedTime)
+                    in
+                    ( DatePicker { model | pickedTime = newTime }, newTime )
 
                 SetMinute minute ->
-                    DatePicker { model | pickedTime = Just <| Utilities.setMinuteNotDay minute (Maybe.withDefault (Time.floor Day Time.utc baseTime) model.pickedTime) }
+                    let
+                        newTime =
+                            Just <| Utilities.setMinuteNotDay minute (Maybe.withDefault (Time.floor Day Time.utc baseTime) model.pickedTime)
+                    in
+                    ( DatePicker { model | pickedTime = newTime }, newTime )
 
                 Close ->
-                    DatePicker { model | status = Closed }
+                    ( DatePicker { model | status = Closed }, Nothing )
 
         Closed ->
-            DatePicker model
+            ( DatePicker model, Nothing )
 
 
 classPrefix : String
@@ -344,13 +346,13 @@ viewDay : Settings msg -> Model -> Month -> Maybe Posix -> Parts -> Html msg
 viewDay settings model currentMonth pickedTime day =
     let
         isToday =
-            Maybe.map (\tday -> Utilities.doDaysMatch day (Time.posixToParts Time.utc tday)) settings.today
+            Maybe.map (\tday -> Utilities.doDaysMatch (Time.partsToPosix Time.utc day) tday) settings.today
                 |> Maybe.withDefault False
 
         isPicked =
             case pickedTime of
                 Just time ->
-                    Utilities.doDaysMatch day (Time.posixToParts Time.utc time)
+                    Utilities.doDaysMatch (Time.partsToPosix Time.utc day) time
 
                 Nothing ->
                     False
@@ -377,26 +379,7 @@ viewFooter : Settings msg -> Model -> Maybe Posix -> Html msg
 viewFooter settings model pickedTime =
     div
         [ class (classPrefix ++ "footer") ]
-        [ viewTimePicker settings model pickedTime
-        , div [ class (classPrefix ++ "confirm-button-container") ] [ viewConfirmButton settings pickedTime ]
-        ]
-
-
-viewConfirmButton : Settings msg -> Maybe Posix -> Html msg
-viewConfirmButton settings pickedTime =
-    let
-        ( classStr, confirmAction ) =
-            Maybe.map (\picked -> ( classPrefix ++ "confirm-button", [ onClick <| settings.selectedMsg picked ] )) pickedTime
-                |> Maybe.withDefault ( classPrefix ++ "confirm-button " ++ classPrefix ++ "disabled", [] )
-
-        confirmAttrs =
-            [ class classStr, type_ "button", attribute "aria-label" "confirm" ] ++ confirmAction
-    in
-    button confirmAttrs
-        [ Icons.check
-            |> Icons.withSize 16
-            |> Icons.toHtml []
-        ]
+        [ viewTimePicker settings model pickedTime ]
 
 
 viewTimePicker : Settings msg -> Model -> Maybe Posix -> Html msg


### PR DESCRIPTION
## Changes

Closes: #8 
Closes: #11 
Closes: #13 

- Removes confirmation button
- Improves visual feedback of selected datetimes in duration picker
- Links calendars in duration picker to always move in unison
- Remove internal package import from examples

Duration Picker
![updated-duration-picker](https://user-images.githubusercontent.com/20546636/70648518-7f2cf880-1c4b-11ea-8c6e-e97e4615c34c.gif)

Basic Picker
![updated-basic-picker](https://user-images.githubusercontent.com/20546636/70648536-8bb15100-1c4b-11ea-8faa-6f3fc9b9715a.gif)

