### PR TITLE
Add settings, isFooterDisabled and isMouseOverDisabled

### DIFF
--- a/src/DurationDatePicker.elm
+++ b/src/DurationDatePicker.elm
@@ -608,7 +608,7 @@ viewDay settings model currentMonth day =
                 defaultAttrs
 
             else
-                onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model)) :: defaultAttrs
+                (onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model))) :: defaultAttrs
     in
     div
         attrs

--- a/src/DurationDatePicker.elm
+++ b/src/DurationDatePicker.elm
@@ -95,6 +95,7 @@ type alias Settings msg =
     , dateStringFn : Zone -> Posix -> String
     , timeStringFn : Zone -> Posix -> String
     , zone : Zone
+    , isMouseOverDisabled : Bool
     }
 
 
@@ -131,6 +132,7 @@ defaultSettings zone internalMsg =
     , dateStringFn = \_ _ -> ""
     , timeStringFn = \_ _ -> ""
     , zone = zone
+    , isMouseOverDisabled = False
     }
 
 
@@ -587,15 +589,20 @@ viewDay settings model currentMonth day =
         dayClasses =
             DatePicker.Styles.durationDayClasses classPrefix (dayParts.month /= currentMonth) isDisabled isPicked isToday isBetween
 
+        defaultAttrs =
+            [ class dayClasses
+            , onClick <| settings.internalMsg (update settings SetRange (DatePicker model))
+            ]
+
         attrs =
             if isDisabled then
                 [ class dayClasses ]
 
+            else if settings.isMouseOverDisabled then
+                defaultAttrs
+
             else
-                [ class dayClasses
-                , onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model))
-                , onClick <| settings.internalMsg (update settings SetRange (DatePicker model))
-                ]
+                onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model)) :: defaultAttrs
     in
     div
         attrs

--- a/src/DurationDatePicker.elm
+++ b/src/DurationDatePicker.elm
@@ -96,6 +96,7 @@ type alias Settings msg =
     , timeStringFn : Zone -> Posix -> String
     , zone : Zone
     , isMouseOverDisabled : Bool
+    , isFooterDisabled : Bool
     }
 
 
@@ -133,6 +134,7 @@ defaultSettings zone internalMsg =
     , timeStringFn = \_ _ -> ""
     , zone = zone
     , isMouseOverDisabled = False
+    , isFooterDisabled = False
     }
 
 
@@ -449,7 +451,11 @@ view settings (DatePicker model) =
                         [ class (classPrefix ++ "calendar") ]
                         [ viewCalendar settings model rightViewTime ]
                     ]
-                , div [ class (classPrefix ++ "footer-container") ] [ viewFooter settings model ]
+                , if settings.isFooterDisabled then
+                    text ""
+
+                  else
+                    div [ class (classPrefix ++ "footer-container") ] [ viewFooter settings model ]
                 ]
 
         Closed ->

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -506,7 +506,7 @@ viewDay settings model currentMonth pickedTime day =
                 defaultAttrs
 
             else
-                (onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model))) :: defaultAttrs
+                onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model)) :: defaultAttrs
     in
     div
         attrs

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -95,6 +95,7 @@ type alias Settings msg =
     , timeStringFn : Zone -> Posix -> String
     , zone : Zone
     , isMouseOverDisabled : Bool
+    , isFooterDisabled : Bool
     }
 
 
@@ -127,6 +128,7 @@ defaultSettings zone internalMsg =
     , timeStringFn = \_ _ -> ""
     , zone = zone
     , isMouseOverDisabled = False
+    , isFooterDisabled = False
     }
 
 
@@ -367,7 +369,11 @@ view settings (DatePicker model) =
                     [ viewCalendarHeader settings model offsetTime
                     , viewMonth settings model model.pickedTime offsetTime
                     ]
-                , viewFooter settings model
+                , if settings.isFooterDisabled then
+                    text ""
+
+                  else
+                    viewFooter settings model
                 ]
 
         Closed ->

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -512,7 +512,7 @@ viewDay settings model currentMonth pickedTime day =
                 defaultAttrs
 
             else
-                onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model)) :: defaultAttrs
+                (onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model))) :: defaultAttrs
     in
     div
         attrs

--- a/src/SingleDatePicker.elm
+++ b/src/SingleDatePicker.elm
@@ -94,6 +94,7 @@ type alias Settings msg =
     , dateStringFn : Zone -> Posix -> String
     , timeStringFn : Zone -> Posix -> String
     , zone : Zone
+    , isMouseOverDisabled : Bool
     }
 
 
@@ -125,6 +126,7 @@ defaultSettings zone internalMsg =
     , dateStringFn = \_ _ -> ""
     , timeStringFn = \_ _ -> ""
     , zone = zone
+    , isMouseOverDisabled = False
     }
 
 
@@ -491,15 +493,20 @@ viewDay settings model currentMonth pickedTime day =
         dayClasses =
             DatePicker.Styles.singleDayClasses classPrefix (dayParts.month /= currentMonth) isDisabled isPicked isToday
 
+        defaultAttrs =
+            [ class dayClasses
+            , onClick <| settings.internalMsg (update settings SetDay (DatePicker model))
+            ]
+
         attrs =
             if isDisabled then
                 [ class dayClasses ]
 
+            else if settings.isMouseOverDisabled then
+                defaultAttrs
+
             else
-                [ class dayClasses
-                , onClick <| settings.internalMsg (update settings SetDay (DatePicker model))
-                , onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model))
-                ]
+                (onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model))) :: defaultAttrs
     in
     div
         attrs


### PR DESCRIPTION
I added two new settings to both date picker settings:

- `isFooterDisabled : Bool` Because sometimes users just don't care about times, just the dates and it looks cleaner without it if you don't need it.
- `isMouseOverDisabled : Bool` because it seems to be causing problems on touch screens on android devices. I'm not sure if this mouse over is necessary, but if not then I think having a setting to disable it is a good idea.