### PR TITLE
Various changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ update msg model =
             ( { model | picker = DatePicker.openPicker model.zone model.today model.pickedTime model.picker }, Cmd.none )
 
         UpdatePicker ( newPicker, maybeNewTime ) ->
-            ( { model | picker = newPicker, pickedTime = Maybe.map (\t -> Just t) maybeNewTime |> Maybe.withDefault model.pickedTime }, Cmd.none )
+            ( { model | picker = newPicker, pickedTime = Maybe.withDefault model.pickedTime maybeNewTime }, Cmd.none )
 ```
 
 The user is responsible for defining his or her own `Open` picker message and placing the relevant event listener where he or she pleases. When handling this message in the `update` as seen above, we call `DatePicker.openPicker` which simply returns an updated picker instance to be stored on the model (`DatePicker.closePicker` is also provided and returns an updated picker instance like `openPicker` does). `DatePicker.openPicker` takes a `Zone` (the time zone in which to display the picker), `Posix` (the base time), a `Maybe Posix` (the picked time), and the `DatePicker` instance we wish to open. The base time is used to inform the picker what day it should center on in the event no datetime has been selected yet. This could be the current date or another date of the implementer's choosing.
@@ -106,7 +106,7 @@ In the event you want the picker to close automatically when clicking outside of
 ```elm
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    SingleDatePicker.subscriptions UpdatePicker model.picker
+    SingleDatePicker.subscriptions (userDefinedDatePickerSettings model.zone) UpdatePicker model.picker
 ```
 
 ## Additional Configuration

--- a/css/DurationDatePicker.css
+++ b/css/DurationDatePicker.css
@@ -89,6 +89,7 @@
     background-color: #fff;
     color: #22292f;
     cursor: pointer;
+    border: none;
 }
 
 .elm-datetimepicker-duration--calendar-day:hover {

--- a/css/SingleDatePicker.css
+++ b/css/SingleDatePicker.css
@@ -5,6 +5,7 @@
     font-size: .875rem;
     padding: .75rem;
     border-radius: 5px;
+    z-index: 10;
     box-shadow: 0 2px 16px rgba(0, 0, 0, 0.15)
 }
 
@@ -72,6 +73,7 @@
     background-color: #fff;
     color: #22292f;
     cursor: pointer;
+    border: none;
 }
 
 .elm-datetimepicker-single--calendar-day:hover {

--- a/src/DurationDatePicker.elm
+++ b/src/DurationDatePicker.elm
@@ -33,8 +33,8 @@ import Browser.Events
 import DatePicker.Icons as Icons
 import DatePicker.Styles
 import DatePicker.Utilities as Utilities
-import Html exposing (Html, div, select, span, text)
-import Html.Attributes exposing (class, disabled, id)
+import Html exposing (Html, button, div, select, span, text)
+import Html.Attributes exposing (class, disabled, id, type_)
 import Html.Events exposing (on, onClick, onMouseOut, onMouseOver)
 import Html.Events.Extra exposing (targetValueIntParse)
 import Json.Decode as Decode
@@ -95,6 +95,7 @@ type alias Settings msg =
     , dateStringFn : Zone -> Posix -> String
     , timeStringFn : Zone -> Posix -> String
     , zone : Zone
+    , isFooterDisabled : Bool
     }
 
 
@@ -131,6 +132,7 @@ defaultSettings zone internalMsg =
     , dateStringFn = \_ _ -> ""
     , timeStringFn = \_ _ -> ""
     , zone = zone
+    , isFooterDisabled = False
     }
 
 
@@ -447,7 +449,11 @@ view settings (DatePicker model) =
                         [ class (classPrefix ++ "calendar") ]
                         [ viewCalendar settings model rightViewTime ]
                     ]
-                , div [ class (classPrefix ++ "footer-container") ] [ viewFooter settings model ]
+                , if settings.isFooterDisabled then
+                    text ""
+
+                  else
+                    div [ class (classPrefix ++ "footer-container") ] [ viewFooter settings model ]
                 ]
 
         Closed ->
@@ -593,19 +599,19 @@ viewDay settings model currentMonth day =
 
             else
                 [ class dayClasses
-                , onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model))
                 , onClick <| settings.internalMsg (update settings SetRange (DatePicker model))
+                , onMouseOver <| settings.internalMsg (update settings (SetHoveredDay day) (DatePicker model))
                 ]
     in
-    div
-        attrs
-        [ text (String.fromInt dayParts.day) ]
+    button
+        ([ type_ "button", disabled isDisabled ] ++ attrs)
+        [ text <| String.fromInt dayParts.day ]
 
 
 viewDateTime : Settings msg -> String -> Posix -> Html msg
 viewDateTime settings classString dateTime =
     span []
-        [ text (settings.dateStringFn settings.zone dateTime)
+        [ text <| settings.dateStringFn settings.zone dateTime
         , span [ class (classPrefix ++ classString) ] [ text (settings.timeStringFn settings.zone dateTime) ]
         ]
 


### PR DESCRIPTION
This PR has some changes that I've made on my fork that I found to be an improvement. I'm making this PR so my fork doesn't get too different, but also because I think these changes should be made.

Changes:
- Fixed up the readme to include old api changes, nothing to do with the changes I made
- Added a `isFooterDisabled` setting, so users can decide if they want to show the clock at the bottom of the calendar. Sometimes users just don't care about the time and only need a date, like my app, for example.
- Converted all the div's of individual days into buttons because buttons:
  + are more accessible
  + better for screen readers
  + can be used with keyboard
  + have a disabled property to prevent clicking
- Small css changes to support buttons, and added a z-index on the calendar because it usually needs to be on top of things.
- Changed the `SetDay` Msg in the single date picker file because on many android touchscreens, users cannot click and set a date because the hover is not setting the date. So now the SetDay will actually set the day instead of using the date from the model.hovered that never gets set. Fixes issues on android touchscreens. <- most important change in this pr