### PR TITLE
Select latest seconds for picked end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 NOTE: as is the case in the README, all code snippets below are specific to the `SingleDatePicker`; however, the only real difference between the `SingleDatePicker` and `DurationDatePicker` from an API standpoint is the `Msg` that a user needs to define to handle updates. Keep this in mind when making updates to your code.
 
+## [5.0.1]
+
+Automatically sets the lastest seconds when selecting an end date in the `DurationDatePicker` (e.g. 12:30:59).
 
 ## [4.0.1]
 
 ### **PATCH**
 
 Fix `DurationDatePicker` docs.
-
 
 ## [4.0.0]
 
@@ -96,7 +98,6 @@ New:
 ```elm
 openPicker : Settings msg -> Posix -> Maybe Posix -> DatePicker -> DatePicker
 ```
-
 
 ## [3.0.0]
 
@@ -213,7 +214,6 @@ New functions:
 `dateStringFn` - function to represent the selected day
 `timeStringFn` - function to represent the selected time of day
 
-
 Additionally, the dateTime picker now takes time zones into account. As such, the `Settings` type now expects a `Time.Zone` to be provided to it. The `defaultSettings` fn, `allowedTimesOfDay` fn, `dateStringFn`, and `timeStringFn` all require a `Time.Zone` to be passed as the first argument.
 
 Old settings:
@@ -229,8 +229,8 @@ type alias Settings msg =
     }
 
 type alias MsgConfig msg =
-    { internalMsg : DatePicker -> msg	
-    , externalMsg : Posix -> msg	
+    { internalMsg : DatePicker -> msg
+    , externalMsg : Posix -> msg
     }
 
 defaultSettings : MsgConfig msg -> Settings msg
@@ -310,4 +310,4 @@ Add `isOpen` function to both pickers to allow a user to query if the picker is 
 
 ### **PATCH**
 
-Add tests for Utilities 
+Add tests for Utilities

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-datetime-picker",
     "summary": "a datetime picker component",
     "license": "MIT",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "exposed-modules": [
         "DurationDatePicker",
         "SingleDatePicker"

--- a/src/DatePicker/DurationUtilities.elm
+++ b/src/DatePicker/DurationUtilities.elm
@@ -108,7 +108,7 @@ selectDay zone previousStartSelectionTuple previousEndSelectionTuple selectedPic
 
                 else if Utilities.posixWithinPickerDayBoundaries zone selectedPickerDay selectionStart then
                     -- keep previously picked time of day
-                    ( Just ( selectedPickerDay, Utilities.setTimeOfDay zone (Time.toHour zone selectionStart) (Time.toMinute zone selectionStart) selectedPickerDay.start )
+                    ( Just ( selectedPickerDay, Utilities.setTimeOfDay zone (Time.toHour zone selectionStart) (Time.toMinute zone selectionStart) 0 selectedPickerDay.start )
                     , Just ( startPickerDay, startPickerDay.end )
                     )
 
@@ -125,7 +125,7 @@ selectDay zone previousStartSelectionTuple previousEndSelectionTuple selectedPic
                 else if Utilities.posixWithinPickerDayBoundaries zone selectedPickerDay selectionEnd then
                     -- keep previously picked time of day
                     ( Just ( endPickerDay, endPickerDay.start )
-                    , Just ( selectedPickerDay, Utilities.setTimeOfDay zone (Time.toHour zone selectionEnd) (Time.toMinute zone selectionEnd) selectedPickerDay.end )
+                    , Just ( selectedPickerDay, Utilities.setTimeOfDay zone (Time.toHour zone selectionEnd) (Time.toMinute zone selectionEnd) 59 selectedPickerDay.end )
                     )
 
                 else

--- a/src/DatePicker/SingleUtilities.elm
+++ b/src/DatePicker/SingleUtilities.elm
@@ -43,7 +43,7 @@ selectDay zone previousSelectionTuple selectedPickerDay =
             Just ( _, previousSelection ) ->
                 if Utilities.posixWithinPickerDayBoundaries zone selectedPickerDay previousSelection then
                     -- keep previously picked time of day
-                    Just ( selectedPickerDay, Utilities.setTimeOfDay zone (Time.toHour zone previousSelection) (Time.toMinute zone previousSelection) selectedPickerDay.start )
+                    Just ( selectedPickerDay, Utilities.setTimeOfDay zone (Time.toHour zone previousSelection) (Time.toMinute zone previousSelection) 0 selectedPickerDay.start )
 
                 else
                     -- use start of picked day

--- a/src/DatePicker/Utilities.elm
+++ b/src/DatePicker/Utilities.elm
@@ -227,8 +227,8 @@ pickerDayFromPosix zone isDisabledFn allowableTimesFn posix =
             Maybe.map (\fn -> fn zone flooredPosix) allowableTimesFn
                 |> Maybe.withDefault { startHour = 0, startMinute = 0, endHour = 23, endMinute = 59 }
     in
-    { start = setTimeOfDay zone allowableTimes.startHour allowableTimes.startMinute flooredPosix
-    , end = setTimeOfDay zone allowableTimes.endHour allowableTimes.endMinute flooredPosix
+    { start = setTimeOfDay zone allowableTimes.startHour allowableTimes.startMinute 0 flooredPosix
+    , end = setTimeOfDay zone allowableTimes.endHour allowableTimes.endMinute 59 flooredPosix
     , disabled = isDisabledFn zone (Time.floor Day zone flooredPosix)
     }
 
@@ -319,14 +319,14 @@ dayToNameString day =
 
 {-| Set the hour and minute of the provided dateTime.
 -}
-setTimeOfDay : Zone -> Int -> Int -> Posix -> Posix
-setTimeOfDay zone hour minute timeToUpdate =
+setTimeOfDay : Zone -> Int -> Int -> Int -> Posix -> Posix
+setTimeOfDay zone hour minute second timeToUpdate =
     let
         parts =
             Time.posixToParts zone timeToUpdate
 
         newParts =
-            { parts | hour = hour, minute = minute }
+            { parts | hour = hour, minute = minute, second = second }
     in
     Time.partsToPosix zone newParts
 

--- a/tests/DurationUtilitiesTest.elm
+++ b/tests/DurationUtilitiesTest.elm
@@ -256,7 +256,7 @@ suite =
                             in
                             Expect.equal
                                 (DurationUtilities.selectDay timeZone Nothing (Just priorEndSelection) pickerDay)
-                                ( Just ( endDay, endDay.start ), Just ( pickerDay, Time.partsToPosix timeZone (Parts 2021 Jan 2 16 0 0 0) ) )
+                                ( Just ( endDay, endDay.start ), Just ( pickerDay, Time.partsToPosix timeZone (Parts 2021 Jan 2 16 0 59 0) ) )
                     , test "provided day becomes new end and end time is provided day end if prior end time not selectable in provided day." <|
                         \_ ->
                             let

--- a/tests/UtilitiesTest.elm
+++ b/tests/UtilitiesTest.elm
@@ -172,7 +172,7 @@ suite =
                     Expect.equal
                         (Utilities.pickerDayFromPosix timeZone (\_ _ -> True) Nothing (Time.partsToPosix timeZone (Parts 2021 Jan 1 0 0 0 0)))
                         { start = Time.partsToPosix timeZone (Parts 2021 Jan 1 0 0 0 0)
-                        , end = Time.partsToPosix timeZone (Parts 2021 Jan 1 23 59 0 0)
+                        , end = Time.partsToPosix timeZone (Parts 2021 Jan 1 23 59 59 0)
                         , disabled = True
                         }
             , test "takes allowable times function into account or defaults to start and end of posix's parent day" <|
@@ -186,11 +186,11 @@ suite =
                         , Utilities.pickerDayFromPosix timeZone (\_ _ -> False) (Just allowableTimesFn) (Time.partsToPosix timeZone (Parts 2021 Jan 1 0 0 0 0))
                         ]
                         [ { start = Time.partsToPosix timeZone (Parts 2021 Jan 1 0 0 0 0)
-                          , end = Time.partsToPosix timeZone (Parts 2021 Jan 1 23 59 0 0)
+                          , end = Time.partsToPosix timeZone (Parts 2021 Jan 1 23 59 59 0)
                           , disabled = False
                           }
                         , { start = Time.partsToPosix timeZone (Parts 2021 Jan 1 9 30 0 0)
-                          , end = Time.partsToPosix timeZone (Parts 2021 Jan 1 17 30 0 0)
+                          , end = Time.partsToPosix timeZone (Parts 2021 Jan 1 17 30 59 0)
                           , disabled = False
                           }
                         ]
@@ -203,7 +203,7 @@ suite =
                         ( 9, 30 )
             ]
         , describe "setTimeOfDay"
-            [ test "updates the hour and minute of the provided Posix" <|
+            [ test "updates the hour, minute, and second of the provided Posix" <|
                 \_ ->
                     let
                         dateTimeToUpdate =
@@ -212,7 +212,7 @@ suite =
                         expectedResult =
                             Time.partsToPosix timeZone (Parts 2019 Sep 19 12 30 0 0)
                     in
-                    Expect.equal (Utilities.setTimeOfDay timeZone 12 30 dateTimeToUpdate) expectedResult
+                    Expect.equal (Utilities.setTimeOfDay timeZone 12 30 0 dateTimeToUpdate) expectedResult
             ]
         , describe "setHourNotDay"
             [ test "updates only the hour of the provided Posix" <|


### PR DESCRIPTION
Automatically sets the lastest seconds when selecting an end date in the duration-date-picker.